### PR TITLE
Add a copy button for small UX improvement

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -71,7 +71,10 @@
                     Your unique identifier is: <code>GUID</code>. You can use the
                     payload below for testing:
                     <div style="text-align: center">
-                        <pre>PAYLOAD</pre>
+                        <pre id="payload">PAYLOAD</pre>
+                        <button class="btn btn-primary" onclick="copyText();">Copy Code</button>
+                        <!-- Styles added to prevent button are content below from shifting layout in undesired ways -->
+                        <span id="copy-confirmed" style="min-width: 60px; display: inline-block; margin-left: 8px;"></span>
                     </div>
                 </p>
 
@@ -95,5 +98,27 @@
                 <span class="text-muted">Created by <a href="https://twitter.com/calebjstewart">@calebjstewart</a>, <a href="https://www.linkedin.com/in/jslagle/">Jason Slagle</a> and <a href="https://twitter.com/_JohnHammond">@_JohnHammond</a>.</span>
             </div>
         </footer>
+
+        <script>
+          function copyText() {
+            /* Get the code text */
+            var copyText = document.getElementById("payload").textContent;
+             /* Copy the text inside the text field */
+            navigator.clipboard.writeText(copyText);
+            /* Calls the function immediately below */
+            confirmCopied();
+          }
+
+          function confirmCopied(){
+            /* Get the notification element */
+            var notification = document.getElementById("copy-confirmed");
+            /* Let the user know the text has been successfully copied */
+            notification.innerHTML = "Copied!";
+            /* Clear the notification */
+            setTimeout(function(){
+              notification.innerHTML = "";
+            }, 3000);
+          }
+        </script>
     </body>
 </html>

--- a/src/main/resources/view.html
+++ b/src/main/resources/view.html
@@ -28,7 +28,10 @@
                     and check back here for any results. Your payload is:
 
                     <div style="text-align: center">
-                        <pre>PAYLOAD</pre>
+                        <pre id="payload">PAYLOAD</pre>
+                        <button class="btn btn-primary" onclick="copyText();">Copy Code</button>
+                        <!-- Styles added to prevent button are content below from shifting layout in undesired ways -->
+                        <span id="copy-confirmed" style="min-width: 60px; display: inline-block; margin-left: 8px;"></span>
                     </div>
                 </p>
 
@@ -79,6 +82,28 @@
             <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
         </symbol>
         </svg>
+
+        <script>
+          function copyText() {
+            /* Get the code text */
+            var copyText = document.getElementById("payload").textContent;
+             /* Copy the text inside the text field */
+            navigator.clipboard.writeText(copyText);
+            /* Calls the function immediately below */
+            confirmCopied();
+          }
+
+          function confirmCopied(){
+            /* Get the notification element */
+            var notification = document.getElementById("copy-confirmed");
+            /* Let the user know the text has been successfully copied */
+            notification.innerHTML = "Copied!";
+            /* Clear the notification */
+            setTimeout(function(){
+              notification.innerHTML = "";
+            }, 3000);
+          }
+        </script>
 
     </body>
 </html>


### PR DESCRIPTION
Hello Huntress Labs,

Thank you for making this app available, it is exactly what I've been looking for to verify my systems are safe. This pull request adds a small UX improvement to make copying the code snippet easier for people using this application.

Cheers,

Ian

edit: After doing some testing, I found a big win with this feature. Many non-techy users don't understand the precision needed with correct code syntax. The lamen user may not copy the entire string needed to test correctly. This copy ensures the entire string is copied.