### PR TITLE
Added ease of deployment changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ FROM openjdk:18-alpine
 COPY --from=build /log4shell/target/log4shell-jar-with-dependencies.jar /log4shell.jar
 
 # Entrypoint, you must provide arguments
-ENTRYPOINT ["java", "-cp", "/log4shell.jar", "com.huntresslabs.log4shell.App"]
+ENTRYPOINT ["java", "-jar", "/log4shell.jar"]
+
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  redis:
+    image: redis:alpine
+    container_name: redis_db
+    command: redis-server 
+    # ports:
+    #   - "6379:6379"
+    restart: always
+    network_mode: host
+
+  log4j-tester:
+    depends_on:
+      - redis
+    build: .
+    # ports:
+    #   - "8001:8000"
+    #   - "1389:1389"
+    network_mode: host
+# put CLI commands here to override defaults
+    command: --hostname 0.0.0.0 --http-host 0.0.0.0 --http-port 8000 --ldap-host 0.0.0.0 --ldap-port 1389 --redis-url "redis://localhost:6379"


### PR DESCRIPTION
- Removed hardcoded command in dockerfile
- Added docker-compose file for easy spin ups
- There is an issue connecting to a redis container from the java connection agent. current workaround is to use the host network running to the container to expose the ports. Not ideal but works. i.e. The Java redis library doesn't know how to work with docker container name DNS resolution presently and fails when it tries to generate a new UUID