### PR TITLE
Remove REDIS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,6 @@ mvn clean package
 You will then have a file named `target/log4shell-jar-with-dependencies.jar`
 which contains all required dependencies as well as the testing application.
 
-## Runtime Requirements
-
-The application is self-contained in the generated JAR file, however it does
-require a Redis cache server at runtime. The URL for the redis cache is
-specified through command line arguments. The cache server will hold valid
-UUIDs for users as well as track known "hits" for the LDAP endpoint.
-
 ## Running
 
 The JAR file can be executed directly. Configuration can be passed via command

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ run out of the same process. After receiving a connection from a vulnerable clie
 it will immediately respond with an LDAP Operation Error. **No code is sent from
 our LDAP server to your client**. You can see this interaction in `LDAPServer.java`.
 After sending the error, the LDAP server will simply log the UTC timestamp and the
-remote IP address in the Redis cache for you to lookup later.
+remote IP address in the cache for you to lookup later.
 
 If any of your clients do reach out, you can view the timestamps and external IP
 addresses at your specific "view" URL (presented through a button on the index
 page).
 
 All entries in the cache have a 30 minute time-out. This means that 30 minutes after
-your last request, all results will be gone from the Redis cache forever.
+your last request, all results will be gone from the cache forever.
 
 ## Building
 
@@ -66,7 +66,6 @@ $ java -jar target/log4shell-jar-with-dependencies.jar --help
 Usage: log4shell-tester [-hV] [-c=<config_file>] [--hostname=<hostname>]
                         [--http-host=<http_host>] [--http-port=<http_port>]
                         [--ldap-host=<ldap_host>] [--ldap-port=<ldap_port>]
-                        [--redis-url=<redis_url>]
 Execute the Huntress Log4Shell-Tester HTTP and LDAP servers.
   -c, --config=<config_file>
                   Path to YAML configuration file (overrides commandline
@@ -85,9 +84,6 @@ Execute the Huntress Log4Shell-Tester HTTP and LDAP servers.
                     0.0.0.0)
       --ldap-port=<ldap_port>
                   Port to listen for LDAP connections (default: 1389)
-      --redis-url=<redis_url>
-                  Connection string for the Redis cache server (default: redis:
-                    //localhost:6379)
   -V, --version   Print version information and exit.
   
 # Example invocation listening on 127.0.0.1 for HTTP (default).
@@ -99,7 +95,6 @@ $ java -jar target/log4shell-jar-with-dependencies.jar \
    --http-port 8000 \
    --ldap-host 0.0.0.0 \
    --ldap-port 1389 \
-   --redis-url "redis://my-redis-url.something.com:6379"
    
 # Example invocation allowing HTTP inbound externally
 $ java -jar target/log4shell-jar-with-dependencies.jar \
@@ -108,10 +103,8 @@ $ java -jar target/log4shell-jar-with-dependencies.jar \
    --http-port 8000 \
    --ldap-host 0.0.0.0 \
    --ldap-port 1389 \
-   --redis-url "redis://:password@my-redis-url.something.com:6379"
    
-# Example invocation with a configuration file (recommended to better store
-#   redis secrets).
+# Example invocation with a configuration file .
 $ java -jar target/log4shell-jar-with-dependencies.jar \
    --config /path/to/log4shell/config.yaml
 ```
@@ -130,7 +123,6 @@ http_host: 127.0.0.1
 http_port: 8000
 ldap_host: 0.0.0.0
 ldap_port: 1389
-redis_url: redis://localhost:6379
 hostname: 127.0.0.1
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
             <version>${undertow.version}</version>
     </dependency>
     <dependency>
-        <groupId>io.lettuce</groupId>
-        <artifactId>lettuce-core</artifactId>
-        <version>6.1.5.RELEASE</version>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>3.0.5</version>
     </dependency>
     <dependency>
       <groupId>info.picocli</groupId>

--- a/src/main/java/com/huntresslabs/log4shell/IndexHandler.java
+++ b/src/main/java/com/huntresslabs/log4shell/IndexHandler.java
@@ -1,49 +1,38 @@
 package com.huntresslabs.log4shell;
 
-import java.util.UUID;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
+import com.github.benmanes.caffeine.cache.Cache;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 public class IndexHandler implements HttpHandler {
 
-    private RedisClient redis;
+    private Cache<String, List<String>> cache;
     private String url;
     private String indexHTML;
 
-    public IndexHandler(RedisClient redis, String url) {
-        this.redis = redis;
+    public IndexHandler(Cache<String, List<String>> cache, String url) {
+        this.cache = cache;
         this.url = url;
         this.indexHTML = App.readResource("index.html");
     }
 
     @Override
     public void handleRequest(HttpServerExchange exchange) {
+        // Generate a random UUID
+        String uuid = UUID.randomUUID().toString();
 
-        // Connect to redis cache
-        StatefulRedisConnection<String, String> conn = redis.connect();
+        // Store the GUID
+        cache.put(uuid, new ArrayList<>());
 
-        try {
-            RedisCommands<String, String> commands = conn.sync();
+        String response = indexHTML.replace("GUID", uuid);
+        response = response.replace("PAYLOAD", "${jndi:" + this.url + "/" + uuid + "}");
 
-            // Generate a random UUID
-            String uuid = UUID.randomUUID().toString();
-
-            // Store the GUID
-            commands.lpush(uuid, "exists");
-            commands.expire(uuid, 1800);
-
-            String response = indexHTML.replace("GUID", uuid);
-            response = response.replace("PAYLOAD", "${jndi:"+this.url+"/"+uuid+"}");
-
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");
-            exchange.getResponseSender().send(response.toString());
-        } finally {
-            conn.close();
-        }
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");
+        exchange.getResponseSender().send(response.toString());
     }
 }

--- a/src/main/java/com/huntresslabs/log4shell/JsonHandler.java
+++ b/src/main/java/com/huntresslabs/log4shell/JsonHandler.java
@@ -1,74 +1,57 @@
 package com.huntresslabs.log4shell;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.google.gson.Gson;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 
-import com.google.gson.Gson;
+import java.util.*;
 
 public class JsonHandler implements HttpHandler {
 
-    private RedisClient redis;
+    private Cache<String, List<String>> cache;
 
-    public JsonHandler(RedisClient redis) {
-        this.redis = redis;
+    public JsonHandler(Cache<String, List<String>> cache) {
+        this.cache = cache;
     }
 
     @Override
     public void handleRequest(HttpServerExchange exchange) {
-        StatefulRedisConnection<String, String> connection = redis.connect();
+        // Grab the UUID
+        String uuid = Optional.ofNullable(exchange.getQueryParameters().get("uuid").getFirst()).orElse("");
 
-        try {
-            RedisCommands<String, String> commands = connection.sync();
-
-            // Grab the UUID
-            String uuid = Optional.ofNullable(exchange.getQueryParameters().get("uuid").getFirst()).orElse("");
-
-            // Make sure this UUID is real
-            if( commands.exists(uuid) == 0 ) {
-                HTTPServer.notFoundHandler(exchange);
-                return;
-            }
-
-            Gson gson = new Gson();
-            Collection<Map<String,String>> entries = new ArrayList<Map<String, String>>();
-            List<String> hits = commands.lrange(uuid, 0, commands.llen(uuid));
-
-            for(String hit : hits) {
-                if( hit == "exists" ) continue;
-
-                // Parse out datetime and IP
-                String[] values = hit.split("/");
-                if( values.length != 2 ) continue;
-
-                // Append to results
-                Map<String, String> entry = new HashMap<String, String>();
-                entry.put("ip", values[0]);
-                entry.put("timestamp", values[1]);
-
-                entries.add(entry);
-            }
-
-            Map<String, Object> result = new HashMap<String, Object>();
-            result.put("uuid", uuid);
-            result.put("hits", entries);
-
-            // Send the response w/ HTML type
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-            exchange.getResponseSender().send(gson.toJson(result));
-
-        } finally {
-            connection.close();
+        // Make sure this UUID is real
+        List<String> hits = cache.getIfPresent(uuid);
+        if (hits == null) {
+            HTTPServer.notFoundHandler(exchange);
+            return;
         }
+
+        Gson gson = new Gson();
+        Collection<Map<String, String>> entries = new ArrayList<Map<String, String>>();
+
+        for (String hit : hits) {
+            if (hit == "exists") continue;
+
+            // Parse out datetime and IP
+            String[] values = hit.split("/");
+            if (values.length != 2) continue;
+
+            // Append to results
+            Map<String, String> entry = new HashMap<String, String>();
+            entry.put("ip", values[0]);
+            entry.put("timestamp", values[1]);
+
+            entries.add(entry);
+        }
+
+        Map<String, Object> result = new HashMap<String, Object>();
+        result.put("uuid", uuid);
+        result.put("hits", entries);
+
+        // Send the response w/ HTML type
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+        exchange.getResponseSender().send(gson.toJson(result));
     }
 }

--- a/src/main/java/com/huntresslabs/log4shell/LDAPServer.java
+++ b/src/main/java/com/huntresslabs/log4shell/LDAPServer.java
@@ -1,13 +1,6 @@
 package com.huntresslabs.log4shell;
 
-import java.lang.reflect.Field;
-import java.net.InetAddress;
-import java.time.Instant;
-
-import javax.net.ServerSocketFactory;
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLSocketFactory;
-
+import com.github.benmanes.caffeine.cache.Cache;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
@@ -16,12 +9,15 @@ import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
 import com.unboundid.ldap.listener.interceptor.InMemoryOperationInterceptor;
 import com.unboundid.ldap.sdk.LDAPResult;
 import com.unboundid.ldap.sdk.ResultCode;
-
 import org.jboss.logging.Logger;
 
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
+import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.List;
 
 /**
  * LDAP Server Thread which caches validated requests
@@ -34,17 +30,17 @@ public class LDAPServer
         logger.infof("ldap query with %s uuid \"%s\" received from %s; dropping request.", valid ? "valid" : "invalid", uuid, address);
     }
 
-    public static void run(String host, int port, RedisClient redis) {
+    public static void run(String host, int port, Cache<String, List<String>> cache) {
         try {
             InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(
-                "dc=example,dc=com"
+                    "dc=example,dc=com"
             );
 
             config.setListenerConfigs(new InMemoryListenerConfig(
-                "listen",
-                InetAddress.getByName(host),
-                port,
-                ServerSocketFactory.getDefault(),
+                    "listen",
+                    InetAddress.getByName(host),
+                    port,
+                    ServerSocketFactory.getDefault(),
                 SocketFactory.getDefault(),
                 (SSLSocketFactory)SSLSocketFactory.getDefault()
             ));
@@ -53,48 +49,40 @@ public class LDAPServer
                 @Override
                 public void processSearchResult ( InMemoryInterceptedSearchResult result ) {
                     String key = result.getRequest().getBaseDN();
-                    StatefulRedisConnection<String, String> connection = redis.connect();
 
+                    LDAPListenerClientConnection conn;
+
+                    // Send an error response regardless
+                    result.setResult(new LDAPResult(0, ResultCode.OPERATIONS_ERROR));
+
+                    // This is a gross reflection block to get the client address
                     try {
-                        RedisCommands<String, String> commands = connection.sync();
-                        LDAPListenerClientConnection conn;
+                        Field field = result.getClass().getSuperclass().getDeclaredField("clientConnection");
+                        field.setAccessible(true);
 
-                        // Send an error response regardless
-                        result.setResult(new LDAPResult(0, ResultCode.OPERATIONS_ERROR));
-
-                        // This is a gross reflection block to get the client address
-                        try {
-                            Field field = result.getClass().getSuperclass().getDeclaredField("clientConnection");
-                            field.setAccessible(true);
-
-                            conn = (LDAPListenerClientConnection)field.get(result);
-                        } catch ( Exception e2 ) {
-                            e2.printStackTrace();
-                            return;
-                        }
-
-                        // Build the resulting value, storing the UTC timestamp and the requestor address
-                        String when = Instant.now().toString();
-                        String addr = conn.getSocket().getInetAddress().toString().replaceAll("^/", "");
-                        String value = addr + "/" + when;
-                        Boolean valid = (commands.exists(key) != 0);
-
-                        // Log any requests
-                        log_attempt(addr, key, valid);
-
-                        // Ignore requests with invalid UUIDs
-                        if ( ! valid ) {
-                            return;
-                        }
-
-                        // Store this result
-                        commands.lpush(key, value);
-
-                        // Keys expire after 30 minutes from creation...
-                        // commands.expire(key, 1800);
-                    } finally {
-                        connection.close();
+                        conn = (LDAPListenerClientConnection) field.get(result);
+                    } catch (Exception e2) {
+                        e2.printStackTrace();
+                        return;
                     }
+
+                    // Build the resulting value, storing the UTC timestamp and the requestor address
+                    String when = Instant.now().toString();
+                    String addr = conn.getSocket().getInetAddress().toString().replaceAll("^/", "");
+                    String value = addr + "/" + when;
+                    List<String> hits = cache.getIfPresent(key);
+                    Boolean valid = (hits != null);
+
+                    // Log any requests
+                    log_attempt(addr, key, valid);
+
+                    // Ignore requests with invalid UUIDs
+                    if (!valid) {
+                        return;
+                    }
+
+                    // Store this result
+                    hits.add(0, value);
                 }
             });
             InMemoryDirectoryServer ds = new InMemoryDirectoryServer(config);

--- a/src/main/java/com/huntresslabs/log4shell/ViewHandler.java
+++ b/src/main/java/com/huntresslabs/log4shell/ViewHandler.java
@@ -1,69 +1,58 @@
 package com.huntresslabs.log4shell;
 
-import java.util.List;
-import java.util.Optional;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
+import com.github.benmanes.caffeine.cache.Cache;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 
+import java.util.List;
+import java.util.Optional;
+
 public class ViewHandler implements HttpHandler {
 
-    private RedisClient redis;
+    private Cache<String, List<String>> cache;
     private String url;
     private String viewHTML;
 
-    public ViewHandler(RedisClient redis, String url) {
-        this.redis = redis;
+    public ViewHandler(Cache<String, List<String>> cache, String url) {
+        this.cache = cache;
         this.url = url;
         this.viewHTML = App.readResource("view.html");
     }
 
     @Override
     public void handleRequest(HttpServerExchange exchange) {
-        StatefulRedisConnection<String, String> connection = redis.connect();
+        // Grab the UUID
+        String uuid = Optional.ofNullable(exchange.getQueryParameters().get("uuid").getFirst()).orElse("");
 
-        try {
-            RedisCommands<String, String> commands = connection.sync();
-
-            // Grab the UUID
-            String uuid = Optional.ofNullable(exchange.getQueryParameters().get("uuid").getFirst()).orElse("");
-
-            // Make sure this UUID is real
-            if( commands.exists(uuid) == 0 ) {
-                HTTPServer.notFoundHandler(exchange);
-                return;
-            }
-
-            // Build the page :sob:
-            StringBuilder body = new StringBuilder();
-
-            // Iterate over all hits
-            List<String> hits = commands.lrange(uuid, 0, commands.llen(uuid));
-            for(String hit : hits) {
-                if( hit == "exists" ) continue;
-
-                // Parse out datetime and IP
-                String[] values = hit.split("/");
-                if( values.length != 2 ) continue;
-
-                // Append to results
-                body.append("<tr><td>" + values[0] + "</td><td>" + values[1] + "</td></tr>");
-            }
-
-            String response = viewHTML.replace("BODY", body.toString());
-            response = response.replace("UUID", uuid);
-            response = response.replace("PAYLOAD", "${jndi:"+this.url+"/"+uuid+"}");
-
-            // Send the response w/ HTML type
-            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");
-            exchange.getResponseSender().send(response);
-
-        } finally {
-            connection.close();
+        // Make sure this UUID is real
+        List<String> hits = cache.getIfPresent(uuid);
+        if (hits == null) {
+            HTTPServer.notFoundHandler(exchange);
+            return;
         }
+
+        // Build the page :sob:
+        StringBuilder body = new StringBuilder();
+
+        // Iterate over all hits
+        for (String hit : hits) {
+            if (hit == "exists") continue;
+
+            // Parse out datetime and IP
+            String[] values = hit.split("/");
+            if (values.length != 2) continue;
+
+            // Append to results
+            body.append("<tr><td>" + values[0] + "</td><td>" + values[1] + "</td></tr>");
+        }
+
+        String response = viewHTML.replace("BODY", body.toString());
+        response = response.replace("UUID", uuid);
+        response = response.replace("PAYLOAD", "${jndi:" + this.url + "/" + uuid + "}");
+
+        // Send the response w/ HTML type
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");
+        exchange.getResponseSender().send(response);
     }
 }


### PR DESCRIPTION
For Windows users, having a dependency on REDIS can be a big constraints.

The proposal is to replace REDIS by a 100% java cache (caffeine, see  https://github.com/ben-manes/caffeine ). As a consequence, the tool is 100% self contained (no runtime dependency anymore)